### PR TITLE
Allow for querying by image ID

### DIFF
--- a/controller/images.php
+++ b/controller/images.php
@@ -62,6 +62,7 @@ namespace Controller {
 
             $sources = Lib\Url::Get('sources', [], $vars);
             $limit = Lib\Url::GetInt('limit', 30, $vars);
+            $imageId = Lib\Url::GetInt('imageId', null, $vars);
             $afterId = Lib\Url::GetInt('afterId', null, $vars);
             $postId = Lib\Url::GetInt('postId', null, $vars);
             $externalId = Lib\Url::Get('externalId', null, $vars);
@@ -141,6 +142,10 @@ namespace Controller {
 
                 if ($userName) {
                     $query['userName'] = $userName;
+                }
+
+                if ($imageId) {
+                    $query['imageId'] = $imageId;
                 }
 
                 if ($afterId) {


### PR DESCRIPTION
Can be used to reverse reverence image data based on the CDN URL (convert filename from base 36). Useful for android intent filters.