### PR TITLE
Add missing JS version from /gallery page renders

### DIFF
--- a/controller/gallery.php
+++ b/controller/gallery.php
@@ -14,6 +14,9 @@ namespace Controller {
 
             $action = Lib\Url::Get('action');
 
+            Lib\Display::addKey('use_min_js', USE_MIN_JS);
+            Lib\Display::addKey('js_version', JS_VERSION);
+
             switch ($action) {
                 case 'user':
                     self::_userGalleries();


### PR DESCRIPTION
All pages under `/gallery` basically freezes because of missing js min and version flags from the renderer causing the js bundle to fail to load.